### PR TITLE
supervisor 3.x requires a path in the URL

### DIFF
--- a/lib/container.js
+++ b/lib/container.js
@@ -37,7 +37,7 @@ function Container(args) {
   this.controlUrl = defaults(args.control, {}, {
     protocol: 'http',
     auth: mandatory(args.token),
-    path: null,
+    path: '/supervisor-control',
   });
 
   this.debug = debug('strong-executor:container:' + args.id);

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "pump": "^1.0.0",
     "request": "^2.57.0",
     "strong-control-channel": "^2.x",
-    "strong-supervisor": "^2.0.2",
+    "strong-supervisor": "^3.x",
     "strong-url-defaults": "^1.0.0",
     "tar": "^2.1.1"
   }


### PR DESCRIPTION
Necessary ATM, because of https://github.com/strongloop/strong-supervisor/pull/135

connected to strongloop-internal/scrum-nodeops#754
