### PR TITLE
install: make -C/--control a required argument

### DIFF
--- a/bin/sl-executor-install.txt
+++ b/bin/sl-executor-install.txt
@@ -1,4 +1,4 @@
-usage: %MAIN% [options]
+usage: %MAIN% --control URL [options]
 
 Install the StrongLoop Mesh Executor as a service.
 
@@ -7,7 +7,7 @@ Options:
   -v,--version        Print version and exit.
   -b,--base BASE      Base directory to work in (default is $HOME of the user
                       that executor is run as, see --user).
-  -C,--control URL    Connect to central at this URL.
+  -C,--control URL    Connect to central at this URL (required, no default).
   -u,--user USER      User to run executor as (default is strong-executor).
   -P,--base-port PORT Applications run on PORT + service ID (default 3000).
   -n,--dry-run        Don't write any files.

--- a/test/test-install.js
+++ b/test/test-install.js
@@ -52,7 +52,8 @@ tap.test('bad platform', function(t) {
   install.ignorePlatform = false;
   install.log = logTo(lines);
   install.error = logTo(lines);
-  install(installCmd('--upstart', '10.10'), function(err) {
+  var cmd = installCmd('--control', 'http://token@host', '--upstart', '10.10');
+  install(cmd, function(err) {
     var output = lines.join('\n');
     t.match(err, Error(), 'should fail');
     t.match(output, /Unsupported platform/i, 'should complain about platform');
@@ -96,6 +97,30 @@ tap.test('bad port', function(t) {
   });
 });
 
+tap.test('bad control URL', function(t) {
+  var lines = [];
+  install.log = logTo(lines);
+  install.error = logTo(lines);
+  install(installCmd('--control', 'http://noauth-host/'), function(err) {
+    var output = lines.join('\n');
+    t.match(err, Error(), 'should fail');
+    t.match(output, /Invalid control URL/i, 'should complain about URL');
+    t.end();
+  });
+});
+
+tap.test('bad control URL', function(t) {
+  var lines = [];
+  install.log = logTo(lines);
+  install.error = logTo(lines);
+  install(installCmd('--control', 'token@host'), function(err) {
+    var output = lines.join('\n');
+    t.match(err, Error(), 'should fail');
+    t.match(output, /Invalid control URL/i, 'should complain about URL');
+    t.end();
+  });
+});
+
 tap.test('dry-run', function(t) {
   var lines = [];
   install.log = logTo(lines);
@@ -106,7 +131,7 @@ tap.test('dry-run', function(t) {
     '--force',
     '--base', __dirname,
     '--base-port', '3000',
-    '--control', 'http://localhost:8701/api',
+    '--control', 'http://token@localhost:8701',
     '--job-file', path.join(__dirname, 'upstart-test.conf')
   );
 


### PR DESCRIPTION
Does what it says on the tin.

Also adds the ability to report multiple errors (eg. if both a bad port and a bad URL are given).

Connect to strongloop-internal/scrum-nodeops#797
