### PR TITLE
executor: run app on lowest unused port

### DIFF
--- a/lib/container.js
+++ b/lib/container.js
@@ -49,6 +49,13 @@ function Container(args) {
 }
 util.inherits(Container, EventEmitter);
 
+Object.defineProperty(Container.prototype, 'port', {
+  enumerable: true,
+  get: function() {
+    return Number(this._env.PORT);
+  },
+});
+
 Container.prototype.setEnv = function(env, callback) {
   var self = this;
 

--- a/lib/executor.js
+++ b/lib/executor.js
@@ -3,6 +3,7 @@
 var Container = require('./container');
 var EventEmitter = require('events').EventEmitter;
 var WebsocketChannel = require('strong-control-channel/ws-channel');
+var _ = require('lodash');
 var assert = require('assert');
 var debug = require('./debug')('executor');
 var defaults = require('strong-url-defaults');
@@ -113,7 +114,7 @@ Executor.prototype['cmd-container-deploy'] = function(req, callback) {
   var self = this;
 
   self._containerDestroy(req.id, function() {
-    req.env = extend({PORT: self._basePort + req.id}, req.env);
+    req.env = extend({PORT: self._unusedPort()}, req.env);
     req.options = req.options || {};
     self._containers[req.id] = new self._Container({
       control: self._control,
@@ -243,4 +244,11 @@ Executor.prototype._containerStop = function(id, options, callback) {
   var container = this._containers[id];
   assert(container);
   container.stop(options, callback);
+};
+
+Executor.prototype._unusedPort = function() {
+  var used = _.pluck(this._containers, 'port');
+  var port = this._basePort + 1; // TBD
+  while (_.includes(used, port)) port++;
+  return port;
 };

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
   "dependencies": {
     "async": "^1.2.1",
     "debug": "^2.2.0",
+    "lodash": "^3.10.0",
     "mkdirp": "^0.5.1",
     "posix-getopt": "^1.1.0",
     "pump": "^1.0.0",

--- a/test/test-container.js
+++ b/test/test-container.js
@@ -31,7 +31,7 @@ tap.test('constructor', function(t) {
   var c = new Container({
     control: ws,
     deploymentId: 12345,
-    env: {PORT: 3003},
+    env: {PORT: '3003'},
     id: 3,
     options: {size: 'CPU'},
     token: 'sched-token',
@@ -42,6 +42,7 @@ tap.test('constructor', function(t) {
 
   c.setStartOptions({trace: true});
   t.equal(c._options.trace, true);
+  t.equal(c.port, 3003);
 
   t.end();
 });
@@ -256,9 +257,12 @@ tap.test('setEnv', function(t) {
     options: {size: 'CPU'},
     token: 'sched-token',
   });
-  var env = {this: 'that'};
+  var env = {
+    this: 'that',
+    PORT: '3005',
+  };
 
-  t.plan(3);
+  t.plan(4);
 
   c.restart = function(options, cb) {
     t.false(options.soft, 'hard restart');
@@ -272,6 +276,7 @@ tap.test('setEnv', function(t) {
   c.setEnv(env, function(err) {
     t.equal(c._env, env, 'env set');
     t.equal(err.message, 'fu', 'error pass-thru');
+    t.equal(c.port, 3005, 'port');
     t.end();
   });
 });

--- a/test/test-executor-port-allocation.js
+++ b/test/test-executor-port-allocation.js
@@ -1,0 +1,36 @@
+var Container = require('../lib/container');
+var Executor = require('../lib/executor');
+var tap = require('tap');
+
+tap.test('executor', function(t) {
+  var e = new Executor({
+    basePort: 4000,
+    control: 'http://token@host:66',
+  });
+
+  t.test('port allocation', function(t) {
+    function set(id, port) {
+      e._containers[id] = new Container({
+        env: {
+          PORT: String(port),
+        },
+        control: 'http://hi@',
+        deploymentId: 'X',
+        id: id,
+        options: {},
+        token: 'T',
+      });
+    }
+
+    t.equal(e._unusedPort(), 4001, 'first');
+    set('a', 4001);
+    set('b', 4002);
+    set('d', 4004);
+    t.equal(e._unusedPort(), 4003, 'third');
+    set('c', 4003);
+    t.equal(e._unusedPort(), 4005, 'fifth');
+    delete e._containers.b;
+    t.equal(e._unusedPort(), 4002, 'second');
+    t.end();
+  });
+});

--- a/test/test-executor.js
+++ b/test/test-executor.js
@@ -142,7 +142,7 @@ tap.test('executor', function(t) {
       t.equal(o.control, e._control);
       t.equal(o.deploymentId, req.deploymentId);
       t.equal(o.env.HI, req.env.HI);
-      t.equal(o.env.PORT, 4000 + req.id);
+      t.equal(o.env.PORT, 4001, 'lowest unused port');
       t.equal(o.options.size, req.options.size);
       t.equal(o.token, req.token);
       setImmediate(cb);


### PR DESCRIPTION
This means that the port used is no longer predictable, it can change
between invocations of executor, but nginx/gateway is supposed to route
to the app's port. Ports can still be set using the PORT environment
variable if a predictable port is desired.

connected to strongloop-internal/scrum-nodeops#821